### PR TITLE
hunterizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ x64/
 *.suo
 windows/test/test/
 *.VC.db
+_*
+*.*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,98 @@
 cmake_minimum_required (VERSION 3.5)
-project(nccl)
-find_package(CUDA 7.5 QUIET REQUIRED)
 
-set(NCCL_MAJOR 1)
-set(NCCL_MINOR 3)
-set(NCCL_PATCH 4)
+project(nccl VERSION 1.3.4)
+
+# Define central CUDA version (allowing user overrides):
+set(nccl_CUDA_MAJOR_VERSION 7 CACHE STRING "CUDA MAJOR version to build against")
+set(nccl_CUDA_MINOR_VERSION 5 CACHE STRING "CUDA MINOR version to build against")
+set(nccl_CUDA_VERSION "${nccl_CUDA_MAJOR_VERSION}.${nccl_CUDA_MINOR_VERSION}")
+find_package(CUDA ${nccl_CUDA_VERSION} REQUIRED)
+list(APPEND CUDA_NVCC_FLAGS  "-DCUDA_MAJOR=${nccl_CUDA_MAJOR_VERSION};-DCUDA_MINOR=${nccl_CUDA_MINOR_VERSION}")
 
 # Call add_subdirectory(nccl) after nvcc flags have been set in the parent project to propagate flags to nccl
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-DNCCL_MAJOR=${NCCL_MAJOR} -DNCCL_MINOR=${NCCL_MINOR} -DNCCL_PATCH=${NCCL_PATCH} -DCUDA_MAJOR=7 -DCUDA_MINOR=5")
-file(GLOB SOURCES src/*.cu)
+list(APPEND CUDA_NVCC_FLAGS "-DNCCL_MAJOR=${nccl_VERSION_MAJOR};-DNCCL_MINOR=${nccl_VERSION_MINOR};-DNCCL_PATCH=${nccl_VERSION_PATCH}")
 
+file(GLOB SOURCES src/*.cu)
 cuda_add_library(${PROJECT_NAME} STATIC ${SOURCES})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
+)
+
+option(NCCL_BUILD_TESTS "Build tests" OFF)
+if(NCCL_BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+# Installation (https://github.com/forexample/package-example) {
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * <prefix>/lib/libnccl.a
+#   * header location after install: <prefix>/include/nccl/nccl.h
+#   * headers can be included by C++ code `#include <nccl/nccl.h>`
+install(
+    TARGETS ${PROJECT_NAME} 
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+install(
+    DIRECTORY "src/"
+    DESTINATION "${include_install_dir}/${PROJECT_NAME}"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Config
+#   * <prefix>/lib/cmake/nccl/ncclConfig.cmake
+#   * <prefix>/lib/cmake/nccl/ncclConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+# }

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+find_package(CUDA @nccl_CUDA_VERSION@ REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,39 @@
+# The tests make use libnvToolsExt.a, which is bundled with CUDA TOOLKIT
+# but the library is not exported in a FindCUDA.cmake CUDA_<name>_LIBRARY variable
+# Depending on the platform, this could be in ${CUDA_TOOLKIT_ROOT_DIR}/{lib,lib64,lib32}
+# so we assume it is side-by-side with curand, and use that directory as a hint
+# for the find_library call.
+get_filename_component(CUDA_LIB_PATH ${CUDA_curand_LIBRARY} DIRECTORY)
+find_library(CUDA_nvToolsExt_LIBRARY nvToolsExt HINTS ${CUDA_TOOLKIT_ROOT_DIR} ${CUDA_LIB_PATH})
+if(NOT CUDA_nvToolsExt_LIBRARY)
+  message(FATAL_ERROR "Can't find nvToolsExt")
+endif()
+
+list(APPEND CUDA_LIBRARIES ${CUDA_CUDA_LIBRARY} ${CUDA_curand_LIBRARY} ${CUDA_nvToolsExt_LIBRARY})
+
+# mpi:
+# find_package(MPI)
+# cuda_add_executable(mpi_test mpi/mpi_test.cu include/test_utilities.h)
+# target_include_directories(mpi_test PUBLIC include)
+# target_link_libraries(mpi_test ${PROJECT_NAME} ${CUDA_LIBRARIES} ${MPI_CXX_LIBRARIES})
+# install(TARGETS mpi_test DESTINATION bin)
+
+# single:
+set(single_srcs
+  all_gather_scan
+  all_gather_test
+  all_reduce_scan
+  all_reduce_test
+  broadcast_scan
+  broadcast_test
+  reduce_scan
+  reduce_scatter_scan
+  reduce_scatter_test
+  reduce_test
+)
+
+foreach(name ${single_srcs})
+  cuda_add_executable(${name} single/${name}.cu include/test_utilities.h)
+  target_include_directories(${name} PUBLIC include)
+  target_link_libraries(${name} ${PROJECT_NAME} ${CUDA_LIBRARIES})
+endforeach()


### PR DESCRIPTION
This PR contains Initial CMake/Hunter updates based on the dmlc/nccl fork.  If we ever need to add a branch for the NVIDIA/nccl fork, we can change the names as needed.  NCCL requires CUDA, and we should in theory be able to run CI build tests if we can install CUDA, although CUDA libs are proprietary and require a login, so I'm not currently sure what the best approach is for CI testing in Hunter.  Runtime tests would require NVIDIA GPU's, which I don't believe Appveyor or Travis support.